### PR TITLE
Set empty request body to http.NoBody instead of nil

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -76,7 +76,7 @@ func (lh LambdaHandler) convertLambdaEventToHTTPRequest(e events.APIGatewayV2HTT
 
 func getRequestBody(s string, isBase64Encoded bool) (body io.Reader, contentLength int) {
 	if s == "" {
-		return nil, -1
+		return http.NoBody, -1
 	}
 	if isBase64Encoded {
 		var padding int

--- a/handler_test.go
+++ b/handler_test.go
@@ -28,7 +28,7 @@ func TestLambdaEventToHTTPRequest(t *testing.T) {
 				RawPath: "/path",
 			},
 			expected: func() *http.Request {
-				r, err := http.NewRequest(http.MethodGet, "/path", nil)
+				r, err := http.NewRequest(http.MethodGet, "/path", http.NoBody)
 				if err != nil {
 					panic(err)
 				}
@@ -46,7 +46,7 @@ func TestLambdaEventToHTTPRequest(t *testing.T) {
 				},
 			},
 			expected: func() *http.Request {
-				r, err := http.NewRequest(http.MethodPost, "/path", nil)
+				r, err := http.NewRequest(http.MethodPost, "/path", http.NoBody)
 				if err != nil {
 					panic(err)
 				}
@@ -63,7 +63,7 @@ func TestLambdaEventToHTTPRequest(t *testing.T) {
 				},
 			},
 			expected: func() *http.Request {
-				r, err := http.NewRequest(http.MethodGet, "/path", nil)
+				r, err := http.NewRequest(http.MethodGet, "/path", http.NoBody)
 				if err != nil {
 					panic(err)
 				}
@@ -79,7 +79,7 @@ func TestLambdaEventToHTTPRequest(t *testing.T) {
 				RawQueryString: "a=123&b=456",
 			},
 			expected: func() *http.Request {
-				r, err := http.NewRequest(http.MethodGet, "/path?a=123&b=456", nil)
+				r, err := http.NewRequest(http.MethodGet, "/path?a=123&b=456", http.NoBody)
 				if err != nil {
 					panic(err)
 				}
@@ -145,7 +145,7 @@ func TestLambdaEventToHTTPRequest(t *testing.T) {
 				},
 			},
 			expected: func() *http.Request {
-				r, err := http.NewRequest(http.MethodGet, "/path", nil)
+				r, err := http.NewRequest(http.MethodGet, "/path", http.NoBody)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
`getRequestBody` returns `nil` if the original API Gateway request had an empty body. This can result in a surprise later on if a handler is blindly reading the request's body without checking it isn't nil:

```go
func myHandler(w http.ResponseWriter, r *http.Request) {
	bs, err := io.ReadAll(r.Body) // panic: runtime error: invalid memory address or nil pointer dereference
	// ...
}
```

I believe `http.NoBody` is the correct value used by the Go standard library to set an empty request body.

```go
// server.go:3512
func (h initALPNRequest) ServeHTTP(rw ResponseWriter, req *Request) {
	if req.TLS == nil {
		req.TLS = &tls.ConnectionState{}
		*req.TLS = h.c.ConnectionState()
	}
	if req.Body == nil {
		req.Body = NoBody
	}
// ...
}
```